### PR TITLE
[Fix] 플레이어 점수가 적은 빈도로 점수가 안올라가는 현상

### DIFF
--- a/Assets/PJW/Scene/RopeGame.unity
+++ b/Assets/PJW/Scene/RopeGame.unity
@@ -1730,50 +1730,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 499466934}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &529711976
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 529711978}
-  - component: {fileID: 529711977}
-  m_Layer: 0
-  m_Name: MyRankDebugger
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &529711977
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 529711976}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2b6deda0242f5874cb560b886118b82d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &529711978
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 529711976}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 53.073357, y: 560.76294, z: -74.97367}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &580799271
 GameObject:
   m_ObjectHideFlags: 3
@@ -2151,7 +2107,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0.026}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.12200928, y: -2.524}
+  m_AnchoredPosition: {x: -0.12200928, y: -2.5239868}
   m_SizeDelta: {x: 100.972, y: 98.975}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &736048034
@@ -5348,37 +5304,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1716777576
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1716777577}
-  m_Layer: 0
-  m_Name: Particle System
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1716777577
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1716777576}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 1.1466869, y: 0.39654845, z: 1.7244122}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!1 &1741257662
 GameObject:
   m_ObjectHideFlags: 0
@@ -6076,6 +6001,4 @@ SceneRoots:
   - {fileID: 2119280114}
   - {fileID: 104959593}
   - {fileID: 1998752321}
-  - {fileID: 529711978}
   - {fileID: 1034193590}
-  - {fileID: 1716777577}

--- a/Assets/PJW/Scripts/Player/PlayerController.cs
+++ b/Assets/PJW/Scripts/Player/PlayerController.cs
@@ -68,10 +68,9 @@ namespace PJW
         {
 
             Debug.Log($"[RPCAddRopePassScore] »£√‚µ , isMine={photonView.IsMine}, hasJumped={hasJumped}");
-            if (photonView.IsMine && !isDead && hasJumped)
+            if (photonView.IsMine && !isDead)
             {
                 PhotonNetwork.LocalPlayer.AddRopeGameScore(1);
-                hasJumped = false;
 
                 if (ropePassCountUIManager != null)
                 {
@@ -110,7 +109,6 @@ namespace PJW
             {
                 isGrounded = true;
                 photonView.RPC(nameof(RPCRopeSetJumping), RpcTarget.All, false);
-                hasJumped = false;
             }
             else if (!isDead && collision.gameObject.CompareTag("Rope"))
             {
@@ -133,7 +131,7 @@ namespace PJW
             if (isDead) return;
             isDead = true;
 
-            Vector3 bounceDir = (Vector3.forward + Random.onUnitSphere).normalized;
+            Vector3 bounceDir = (Vector3.up + Random.onUnitSphere).normalized;
             playerRigidbody.AddForce(bounceDir * bounceForce, ForceMode.Impulse);
 
             photonView.RPC(

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -33,7 +33,63 @@ MonoBehaviour:
   EnableSupportLogger: 0
   RunInBackground: 1
   StartInOfflineMode: 0
-  RpcList: []
+  RpcList:
+  - ArenaApplyPushForce
+  - ArenaEndGame
+  - ArenaHitEffect
+  - ArenaKillZoneEffect
+  - ArenaPlayerDied
+  - CheckJumpGamePlayerAlive
+  - ClickRpc
+  - CollectRPC
+  - DeleteJumpGamePlayer
+  - DestroyRpc
+  - DestroySpaceship
+  - Fire
+  - GoNextGame
+  - JumpGame_Jump
+  - JumpGamePlayerOut
+  - JumpGameStart
+  - PlayerArrive
+  - PunRPC_CountTile
+  - RacingCrash
+  - RacingFinish
+  - RacingStart
+  - RacingWorldCrash
+  - RequestObstaclePenalty
+  - RequestScoreIncrease
+  - RequestSpawnPlayer
+  - ResetAllPlayersReadyState
+  - RespawnSpaceship
+  - RetireCount
+  - RPC_CanMove
+  - RPC_Dead
+  - RPC_DontMove
+  - RPCActivateEffect
+  - RPCAddRopePassScore
+  - RPCBeginCountdown
+  - RPCClearAllEffects
+  - RPCDeactivateEffect
+  - RpcNotifyLoaded
+  - RPCRopeNotifyDeath
+  - RPCRopeSetJumping
+  - RPCRopeShowDeathPanel
+  - RpcStartGame
+  - RPCStartRope
+  - SendChatMessage
+  - SetColor
+  - SetControllable
+  - SetDollyCart
+  - SetStartLine
+  - SetTrack
+  - SetupItemTypeRPC
+  - SpawnItemRPC
+  - SpawnObstacle_JumpGame
+  - SpawnObstacleRPC
+  - SpawnPowerUpRPC
+  - StartCount
+  - StopBGMForAllClients
+  - StopRacingSound
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -33,63 +33,7 @@ MonoBehaviour:
   EnableSupportLogger: 0
   RunInBackground: 1
   StartInOfflineMode: 0
-  RpcList:
-  - ArenaApplyPushForce
-  - ArenaEndGame
-  - ArenaHitEffect
-  - ArenaKillZoneEffect
-  - ArenaPlayerDied
-  - CheckJumpGamePlayerAlive
-  - ClickRpc
-  - CollectRPC
-  - DeleteJumpGamePlayer
-  - DestroyRpc
-  - DestroySpaceship
-  - Fire
-  - GoNextGame
-  - JumpGame_Jump
-  - JumpGamePlayerOut
-  - JumpGameStart
-  - PlayerArrive
-  - PunRPC_CountTile
-  - RacingCrash
-  - RacingFinish
-  - RacingStart
-  - RacingWorldCrash
-  - RequestObstaclePenalty
-  - RequestScoreIncrease
-  - RequestSpawnPlayer
-  - ResetAllPlayersReadyState
-  - RespawnSpaceship
-  - RetireCount
-  - RPC_CanMove
-  - RPC_Dead
-  - RPC_DontMove
-  - RPCActivateEffect
-  - RPCAddRopePassScore
-  - RPCBeginCountdown
-  - RPCClearAllEffects
-  - RPCDeactivateEffect
-  - RpcNotifyLoaded
-  - RPCRopeNotifyDeath
-  - RPCRopeSetJumping
-  - RPCRopeShowDeathPanel
-  - RpcStartGame
-  - RPCStartRope
-  - SendChatMessage
-  - SetColor
-  - SetControllable
-  - SetDollyCart
-  - SetStartLine
-  - SetTrack
-  - SetupItemTypeRPC
-  - SpawnItemRPC
-  - SpawnObstacle_JumpGame
-  - SpawnObstacleRPC
-  - SpawnPowerUpRPC
-  - StartCount
-  - StopBGMForAllClients
-  - StopRacingSound
+  RpcList: []
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1


### PR DESCRIPTION
로프를 넘어갈 때 빈도 적게 점수가 안올라가던 현상 수정

- 로프가 한 바퀴를 돌고 플레이어가 점프 상태이면 점수가 오르게 했었지만 360도 마다 점수가 1점 오르는 형식으로 변경 완료